### PR TITLE
When prediction succeeds, add predictoor brand to epoch footer

### DIFF
--- a/src/components/EpochDetails/EpochFooter.tsx
+++ b/src/components/EpochDetails/EpochFooter.tsx
@@ -6,6 +6,7 @@ export type TEpochFooterProps = {
   direction: number
   confidence: number
   stake: number
+  delta: number | undefined
   status: EEpochDisplayStatus
 }
 
@@ -13,6 +14,7 @@ export const EpochFooter: React.FC<TEpochFooterProps> = ({
   direction,
   confidence,
   stake,
+  delta,
   status
 }) => {
   return (
@@ -27,6 +29,13 @@ export const EpochFooter: React.FC<TEpochFooterProps> = ({
           <span className={styles.footerConfidence}>
             {parseFloat(confidence.toString()).toFixed(0)}%
           </span>
+          { delta && ((direction == 1 && delta > 0.0) ||
+            (direction == 0 && delta < 0.0)) && (
+              <div className={styles.eyesContainer}>
+                <div className={styles.eye}></div>
+                <div className={styles.eye}></div>
+              </div>
+          )}
           <EpochStakedTokens stakedAmount={stake} />
         </div>
       ) : (

--- a/src/components/EpochDetails/EpochStakedTokens.tsx
+++ b/src/components/EpochDetails/EpochStakedTokens.tsx
@@ -10,7 +10,7 @@ export const EpochStakedTokens: React.FC<TEpochStakedTokensProps> = ({
   showLabel
 }) => {
   return (
-    <div className={styles.stake}>
+  <div className={styles.stake}>
       <img
         className={styles.tokenImage}
         src={'oceanToken.png'}

--- a/src/components/EpochDisplay.tsx
+++ b/src/components/EpochDisplay.tsx
@@ -127,6 +127,7 @@ export const EpochDisplay: React.FC<TEpochDisplayProps> = ({
                 stake={relatedData.stake}
                 confidence={relatedData.confidence}
                 direction={relatedData.dir}
+                delta={delta}
                 status={status}
               />
             </>

--- a/src/styles/Epoch.module.css
+++ b/src/styles/Epoch.module.css
@@ -59,3 +59,16 @@
   justify-content: center;
   align-items: center;
 }
+
+.eyesContainer {
+  display: flex;
+  justify-content: space-between;
+  width: 19px; /*(eye-radius * 2) + 1*/
+}
+
+.eye {
+  width: 9px;
+  height: 9px;
+  border: 2px solid #FF4292;
+  border-radius: 50%;
+}


### PR DESCRIPTION
Fixes #119 

### In App
![Screenshot from 2023-08-21 14-50-32](https://github.com/oceanprotocol/pdr-web/assets/69865342/d69d1193-e9b6-44eb-bbec-77be25ff91f7)

Color/styling in-app is not representative of figma design.
### Figma Design
![image](https://github.com/oceanprotocol/pdr-web/assets/69865342/3641dedb-1b20-4c9e-a4b5-8a81db7b6241)

I think we need to address some of these details to improve how things look.