### PR TITLE
Issue115 GetHistoricalDataFromSubgraph

### DIFF
--- a/src/components/AssetRow.tsx
+++ b/src/components/AssetRow.tsx
@@ -35,6 +35,7 @@ export const AssetRow: React.FC<TAssetRowProps> = ({ assetData }) => {
     price: 0,
     market: ''
   })
+
   const {
     tokenName,
     pairName,
@@ -103,10 +104,12 @@ export const AssetRow: React.FC<TAssetRowProps> = ({ assetData }) => {
             tokenName,
             pairName,
             subscription,
-            market
+            market,
+            price: tokenData.price,
+            contractAddress: assetData.contract.address
           }
         : null,
-    [tokenName, pairName, subscription]
+    [tokenName, pairName, subscription, tokenData, market, assetData]
   )
 
   useEffect(() => {
@@ -127,14 +130,12 @@ export const AssetRow: React.FC<TAssetRowProps> = ({ assetData }) => {
       <Asset assetData={tokenData} />
       <EpochDisplay
         status={EEpochDisplayStatus.PastEpoch}
-        price={tokenData.price}
         {...slotProps}
         epochStartTs={currentEpoch - secondsPerEpoch}
         secondsPerEpoch={secondsPerEpoch}
       />
       <EpochDisplay
         status={EEpochDisplayStatus.LiveEpoch}
-        price={tokenData.price}
         {...slotProps}
         epochStartTs={currentEpoch}
         secondsPerEpoch={secondsPerEpoch}
@@ -142,7 +143,6 @@ export const AssetRow: React.FC<TAssetRowProps> = ({ assetData }) => {
       <Price assetData={tokenData} />
       <EpochDisplay
         status={EEpochDisplayStatus.NextEpoch}
-        price={tokenData.price}
         {...slotProps}
         epochStartTs={currentEpoch + secondsPerEpoch}
         secondsPerEpoch={secondsPerEpoch}

--- a/src/contexts/PredictionHistoryContext.tsx
+++ b/src/contexts/PredictionHistoryContext.tsx
@@ -1,0 +1,161 @@
+import { calculatePrediction } from '@/utils/calculatePrediction'
+import { getLatestTimestamp } from '@/utils/getLatestBlockTimestamp'
+import { graphqlClientInstance } from '@/utils/graphqlClient'
+import { TPredictionContract } from '@/utils/subgraphs/getAllInterestingPredictionContracts'
+import {
+  TGetHistoryDataReturn,
+  getHistoryDataQuery
+} from '@/utils/subgraphs/queries/getHistoryData'
+import { createContext, useCallback, useContext, useState } from 'react'
+import {
+  TPredictionHistoryContext,
+  TPredictionHistoryContextProps
+} from './PredictionHistoryContext.types'
+
+/**
+ * @description
+ * This context is used to store the history of the predictions
+ * made on the blockchain.
+ */
+export const PredictionHistoryContext =
+  createContext<TPredictionHistoryContext>({
+    historyData: [],
+    renewHistory: () => {},
+    clearHistory: () => {},
+    getDataFromHistoryByContractAddress: () => null
+  })
+
+/**
+ * @description
+ * This hook is used to access the PredictionHistoryContext.
+ */
+export const usePredictionHistoryContext = () =>
+  useContext(PredictionHistoryContext)
+
+/**
+ * @description
+ * This provider is used to store the history of the predictions
+ * on the Context.
+ * It is used to display the history of the predictions on the
+ * Predictoors page.
+ */
+export const PredictionHistoryProvider: React.FC<
+  TPredictionHistoryContextProps
+> = ({ children }) => {
+  const [historyData, setHistoryData] = useState<
+    TPredictionHistoryContext['historyData']
+  >([])
+
+  /**
+   * @description
+   * This function is used to get the history of the predictions
+   * from the subgraph.
+   * @argument contracts: Record<string, TPredictionContract>
+   * @returns Promise<TGetHistoryDataReturn>
+   */
+  const getHistoryFromSubgraph = useCallback<
+    (args: {
+      contracts: Record<string, TPredictionContract>
+    }) => Promise<TGetHistoryDataReturn>
+  >(async ({ contracts }) => {
+    if (!contracts) return Promise.reject()
+
+    const SPE = contracts[Object.keys(contracts)[0]].secondsPerEpoch
+
+    const latestTimestamp = await getLatestTimestamp()
+
+    if (!latestTimestamp) return Promise.reject()
+
+    const lastTwoEpochs = latestTimestamp - parseInt(SPE) * 2
+
+    return new Promise((resolve, reject) => {
+      graphqlClientInstance
+        .query<TGetHistoryDataReturn>(getHistoryDataQuery, {
+          slot_gte: lastTwoEpochs,
+          slot_lte: latestTimestamp,
+          predictionContracts: Object.values(contracts).map(
+            (contract) => contract.address
+          )
+        })
+        .then((result) => {
+          if (result.data) {
+            resolve(result.data)
+          } else {
+            reject()
+          }
+        })
+    })
+  }, [])
+
+  /**
+   * @description
+   * This function is used to renew the history of the predictions
+   * @argument contracts: Record<string, TPredictionContract>
+   * @returns void
+   */
+  const renewHistory = useCallback<
+    (args: { contracts: Record<string, TPredictionContract> }) => void
+  >(
+    ({ contracts }) => {
+      getHistoryFromSubgraph({ contracts }).then((result) => {
+        if (!result.predictSlots) return
+
+        const historyData = result.predictSlots.map((item) => ({
+          predictContractId: item.predictContract.id,
+          slot: item.slot,
+          prediction: calculatePrediction(
+            item.roundSumStakesUp.toString(),
+            item.roundSumStakes.toString()
+          )
+        }))
+
+        setHistoryData(historyData)
+      })
+    },
+    [setHistoryData, getHistoryFromSubgraph]
+  )
+
+  /**
+   * @description
+   * This function is used to clear the history of the predictions
+   */
+  const clearHistory = useCallback(() => {
+    setHistoryData([])
+  }, [setHistoryData])
+
+  /**
+   * @description
+   * This function is used to get the history of the predictions
+   * by contract address.
+   * @argument contractAddress: string
+   * @returns TPredictionHistoryContext['getDataFromHistoryByContractAddress']
+   * @returns null if no data is found
+   * @returns TPredictionHistoryContext['historyData'] if data is found
+   */
+  const getDataFromHistoryByContractAddress = useCallback<
+    TPredictionHistoryContext['getDataFromHistoryByContractAddress']
+  >(
+    ({ contractAddress }) => {
+      const data = historyData.filter(
+        (item) => item.predictContractId === contractAddress
+      )
+      return data.length
+        ? data.map((item) => ({ ...item.prediction, slot: item.slot }))
+        : null
+    },
+    [historyData]
+  )
+
+  return (
+    <PredictionHistoryContext.Provider
+      value={{
+        historyData,
+        renewHistory,
+        clearHistory,
+        getDataFromHistoryByContractAddress
+      }}
+    >
+      {children}
+    </PredictionHistoryContext.Provider>
+  )
+}

--- a/src/contexts/PredictionHistoryContext.types.ts
+++ b/src/contexts/PredictionHistoryContext.types.ts
@@ -1,0 +1,64 @@
+import { TPredictionContract } from '@/utils/subgraphs/getAllInterestingPredictionContracts'
+import { Maybe } from '@/utils/utils'
+
+/**
+ * @name PredictionResult
+ * @description
+ * Data type for the prediction result
+ * @property {string} nom - The numerator
+ * @property {string} denom - The denominator
+ * @property {number} confidence - The calculated confidence by the nom and the denom
+ * @property {number} dir - The calculated direction by the nom and the denom
+ * @property {number} stake - The stake of the prediction
+ */
+export type PredictionResult = {
+  nom: string
+  denom: string
+  confidence: number
+  dir: number
+  stake: number
+}
+
+/**
+ * @name TPredictionHistoryData
+ * @description
+ * Data type for the history data
+ * @property {string} predictContractId - The predict contract id
+ * @property {number} slot - The slot number
+ * @property {PredictionResult} prediction - The prediction result, includes nom, denom, confidence, dir, stake
+ */
+export type TPredictionHistoryData = {
+  predictContractId: string
+  slot: number
+  prediction: PredictionResult
+}
+
+/**
+ * @name TPredictionHistoryContext
+ * @description
+ * Data type for the prediction history context
+ * @property {Array<TPredictionHistoryData>} historyData - The history data
+ * @property {(data: { contracts: Record<string, TPredictionContract> }) => void} renewHistory - The renew history function
+ * @property {() => void} clearHistory - The clear history function
+ * @property {(args: { predictContractId: string; slot: number }) => Maybe<PredictionResult>} getDataFromHistory - The get data from history function
+ */
+export type TPredictionHistoryContext = {
+  historyData: Array<TPredictionHistoryData>
+  renewHistory: (data: {
+    contracts: Record<string, TPredictionContract>
+  }) => void
+  clearHistory: () => void
+  getDataFromHistoryByContractAddress: (args: {
+    contractAddress: string
+  }) => Maybe<Array<TPredictionHistoryData['prediction']>>
+}
+
+/**
+ * @name TPredictionHistoryContextProps
+ * @description
+ * Data type for the prediction history context props
+ * @property {React.ReactNode} children - The children
+ */
+export type TPredictionHistoryContextProps = {
+  children: React.ReactNode
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { PredictionHistoryProvider } from '@/contexts/PredictionHistoryContext'
 import { PredictoorsProvider } from '@/contexts/PredictoorsContext'
 import { SocketProvider } from '@/contexts/SocketContext'
 import { UserProvider } from '@/contexts/UserContext'
@@ -15,9 +16,11 @@ function App({ Component, pageProps }: AppProps) {
       <WagmiConfig config={wagmiConfig}>
         <UserProvider>
           <SocketProvider>
-            <PredictoorsProvider>
-              <Component {...pageProps} />
-            </PredictoorsProvider>
+            <PredictionHistoryProvider>
+              <PredictoorsProvider>
+                <Component {...pageProps} />
+              </PredictoorsProvider>
+            </PredictionHistoryProvider>
           </SocketProvider>
         </UserProvider>
       </WagmiConfig>

--- a/src/utils/calculatePrediction.ts
+++ b/src/utils/calculatePrediction.ts
@@ -1,0 +1,37 @@
+import { PredictionResult } from '@/contexts/PredictionHistoryContext.types'
+
+const calculateConfidence = (nom: string, denom: string): number => {
+  // calculate confidence based on the ratio of the two inputs
+  let confidence: number = parseFloat(nom) / parseFloat(denom)
+  // calculate the difference from 0.5
+  if (confidence > 0.5) {
+    confidence -= 0.5
+  } else {
+    confidence = 0.5 - confidence
+  }
+  // scale the difference to a percentage
+  confidence = (confidence / 0.5) * 100
+
+  return confidence
+}
+
+const calculateDirection = (nom: string, denom: string): number => {
+  // calculate direction based on whether the result is greater than 0.5
+  let dir: number = parseFloat(nom) / parseFloat(denom)
+  return dir >= 0.5 ? 1 : 0
+}
+
+export const calculatePrediction = (
+  nom: string,
+  denom: string
+): PredictionResult => {
+  const confidence: number = calculateConfidence(nom, denom)
+  const dir: number = calculateDirection(nom, denom)
+  return {
+    nom: nom,
+    denom: denom,
+    confidence: confidence,
+    dir: dir,
+    stake: parseFloat(denom)
+  }
+}

--- a/src/utils/getLatestBlockTimestamp.ts
+++ b/src/utils/getLatestBlockTimestamp.ts
@@ -1,0 +1,21 @@
+import { networkProvider } from './networkProvider'
+
+/**
+ * Returns the timestamp of the latest block
+ * @returns The timestamp of the latest block
+ * @throws If the latest block cannot be fetched
+ */
+export const getLatestTimestamp = async (): Promise<number | null> => {
+  const provider = networkProvider.getProvider()
+  // Fetch the latest block from the provider
+  let block
+  try {
+    block = await provider.getBlock('latest')
+  } catch (error) {
+    console.error(error)
+    return null
+  }
+
+  // Return the timestamp of the latest block
+  return block.timestamp
+}

--- a/src/utils/subgraphs/queries/getHistoryData.ts
+++ b/src/utils/subgraphs/queries/getHistoryData.ts
@@ -1,0 +1,35 @@
+export const getHistoryDataQuery = `
+    query GetHistoryData($slot_gte: Int!, $slot_lte: Int! $predictionContracts: [String!]!) {
+        predictSlots(
+            orderBy: slot,
+            orderDirection: desc
+            where: {
+                predictContract_in: $predictionContracts,
+                slot_gte: $slot_gte,
+                slot_lte: $slot_lte
+            }
+        ) {
+        id
+        predictContract {
+            id
+        }
+        slot
+        roundSumStakesUp
+        roundSumStakes
+        }
+    }
+`
+
+export type TPredictSlotsReturn = {
+  id: string
+  predictContract: {
+    id: string
+  }
+  slot: number
+  roundSumStakesUp: number
+  roundSumStakes: number
+}
+
+export type TGetHistoryDataReturn = {
+  predictSlots: TPredictSlotsReturn[]
+}


### PR DESCRIPTION
Fixes #115  .

Changes proposed in this PR:

- the PredictionHistoryContext is created
- the getHistoryData query is added
- two util functions, getLatestBlockTimestamp.ts and calculatePrediction.ts are added. I will replace the calculatePrediction when we merge the PR-135 with the idiom-bytes one
- The trigger logic added to the PredictoorsContext
- the EpochDisplay is changed according to the new logic
- the Assetrow component is refactored