### PR TITLE
Create Terms of Use

### DIFF
--- a/resources/terms.md
+++ b/resources/terms.md
@@ -3,25 +3,23 @@ title: Terms and Conditions
 description: Thanks for using our product and services.
 ---
 
-Predictoor Portal Terms and Conditions (this “**Agreement**”) is made and entered into by and between Ocean Protocol Foundation Ltd., with office at The Commerze @ Irving, 1 Irving Place, #08-11, Singapore, 369546 Singapore (“**Ocean**”) and the legal entity set forth in the Account Information (“**Customer**”). It governs Customer’s access to and use of the Predictoor Portal, Predictoor Feeds, and Predictoor Stack (as defined below) and takes effect on the date of its acceptance by Customer (the “**Effective Date**”). Customer represents being lawfully able to enter into contracts and having legal authority to bind Customer’s entity.
+Predictoor Portal Terms and Conditions (this “**Agreement**”) is made and entered into by and between Ocean Protocol Foundation Ltd., with office at The Commerze @ Irving, 1 Irving Place, #08-11, Singapore, 369546 Singapore (“**Ocean**”) and the legal entity set forth in the Account Information (“**Customer**”). It governs Customer’s access to and use of the Predictoor Portal (as defined below) and takes effect on the date of its acceptance by Customer (the “**Effective Date**”). Customer represents being lawfully able to enter into contracts and having legal authority to bind Customer’s entity.
 
 **DEFINITIONS**
 
 “**API**” means an application program interface.
 
-“**Customer**” means any individual or entity that directly or indirectly through another user: (a) accesses or uses the Predictoor Portal; or (b) accesses or purchases Predictoor Feeds; or (c) accesses or utilizes the Predictoor Stack.
+“**Customer**” means any individual or entity that directly or indirectly through another user: (a) accesses or uses the Predictoor Portal; or (b) accesses or purchases Predictoor Feeds; or (c) accesses or utilizes the Services.
 
 “**Trader**” means any Customer or legal entity and its employees that sources or intends to source external predictions, or utilize the Services provided.
 
 “**Predictoor**” means any Customer or legal entity and its employees that provides or intends to provide predictions, or utilize the Services provided.
 
-“**Documentation**” means the user guides (in each case exclusive of content referenced via hyperlink) for the Predictoor Stack, as such user guides may be updated by Ocean from time to time.
+“**Documentation**” means the user guides (in each case exclusive of content referenced via hyperlink) for the Predictoor Portal, as such user guides may be updated by Ocean from time to time.
 
 “**Predictoor Website**” means the website at https://predictoor.ai or https://test.predictoor.ai (and any successor or related sites designated by Ocean), as may be updated by Ocean from time to time.
 
-“**Predictoor Feeds**” means the prediction feeds that Customers may purchase through Predictoor Portal, or the Predictoor Stack (and any successor or distribution channels designated by Ocean), as may be updated by Ocean from time to time.
-
-"**Predictoor Stack**" means the Predictoor Portal, Predictoor Feeds, Services, and Predictoor DF listed herein (and any successor or related technologies designated by Ocean) that the Customer can access and use in accordance with this Agreement.
+“**Predictoor Feeds**” means the prediction feeds that Customers may purchase through Predictoor Portal (and any successor or distribution channels designated by Ocean), as may be updated by Ocean from time to time.
 
 “**Predictoor DF**” means the incentive emissions operated by Ocean to reward Predictoors for helping to provide accurate predictions, (and any successor or parameter updates designated by Ocean), as may be updated by Ocean from time to time.
 
@@ -31,9 +29,9 @@ Predictoor Portal Terms and Conditions (this “**Agreement**”) is made and en
 
 “**Privacy Policy**” means the privacy policy located at https://www.oceanprotocol.com (and any successor or related locations designated by Ocean), as it may be updated by Ocean from time to time.
 
-“**Allowlist**” means a state in which Ocean tags specific Predictoor Feeds to be visible in the Predictoor Portal and elligible for Predictoor DF rewards. The Allowlist is an artifact of Ocean deploying Predictoor Feeds which are considered officially supported. The Predictoor Portal Allowlist can be accessed here: https://github.com/oceanprotocol/pdr-web/blob/main/src/utils/config.ts
+“**Allowlist**” means a state in which Ocean tags specific Predictoor Feeds to be visible in the Predictoor Portal and elligible for Predictoor DF rewards. The Allowlist is an artifact of deployed Predictoor Feeds that considered officially supported by Ocean. The Predictoor Portal Allowlist can be accessed here: https://github.com/oceanprotocol/pdr-web/blob/main/src/utils/config.ts
 
-“**Service**” means each of the websites, software and services made available by Ocean or its affiliates, including those web services described in the Service Terms. Services do not include Third-Party Content.
+“**Service**” means each of the websites, software, smart contracts, and services made available by Ocean or its affiliates, including those web services described in the Service Terms. Services do not include Third-Party Content.
 
 “**Service Terms**” means the rights and restrictions for particular Services located on the Predictoor Website (and any successor or related locations designated by Ocean), as may be updated by Ocean from time to time.
 
@@ -49,7 +47,7 @@ Predictoor Portal Terms and Conditions (this “**Agreement**”) is made and en
 
 **1.2**    To access Predictoor Feeds and to participate as a Predictoor, the Customer must have a Web3 wallet (e.g. MetaMask) and must have Ocean tokens in their wallet.
 
-**1.3**    The Predictoor Portal connects Predictoors and Traders directly, without any 3rd party control via the Predictoor Portal. This means that while providing predictions as a Predictoor, Customers are responsible for their own activity. This means that while purchasing Prediction Feeds as a Trader, Customers are responsible for their own activity. Customers must adhere to the laws in their own legal jurisdiction as well as their conscience. Ocean is not responsible for any malicious use of the Predictoor Stack or any losses associated with the use of the Predictoor Stack or any source.  
+**1.3**    The Predictoor Portal connects Predictoors and Traders directly, without any 3rd party control via the Predictoor Portal. This means that while providing predictions as a Predictoor, Customers are responsible for their own activity. This means that while purchasing Prediction Feeds as a Trader, Customers are responsible for their own activity. Customers must adhere to the laws in their own legal jurisdiction as well as their conscience. Ocean is not responsible for any malicious use of the Predictoor Portal or any losses associated with the use of the Predictoor Portal or any source.  
 
 **1.4**    By clicking any button or box marked “accept” or “agree” (or a similar term) in connection with this Agreement, or by accessing or using the Predictoor Portal, you agree to be bound by this Agreement, a current version of which is available at the Predictoor Portal, and which may be modified from time to time at our sole discretion. We are only providing our services if you accept all of these terms. By using the Predictoor Portal, the Customer confirms their understanding and agrees to be bound by all of these terms. If Customer accepts these terms on behalf of a company or other legal entity, Customer represents that they have the legal authority to accept these terms on that entity’s behalf, in which case Customer will mean that entity.  If Customer does not accept all of these terms, then you may not access or use the Predictoor Portal.  
 
@@ -69,7 +67,7 @@ Predictoor Portal Terms and Conditions (this “**Agreement**”) is made and en
 
 **3.3**    Transactions that take place on the Predictoor Portal are managed and confirmed via the Oasis blockchain. Your wallet public address will be made publicly visible whenever you engage in a transaction on the Predictoor Portal.
 
-**3.4**    We neither own nor control MetaMask, Coinbase, Celr, Google Chrome, the Oasis network, or any other third parties site, product, or service that you might access, visit, or use for the purpose of enabling you to use the various features of the Predictoor Stack. We will not be liable for the acts or omissions of any such third parties, nor will we be liable for any damage that you may suffer as a result of your transactions or any other interaction with any such third parties.
+**3.4**    We neither own nor control MetaMask, Coinbase, Celr, Google Chrome, the Oasis network, or any other third parties site, product, or service that you might access, visit, or use for the purpose of enabling you to use the various features of the Predictoor Portal. We will not be liable for the acts or omissions of any such third parties, nor will we be liable for any damage that you may suffer as a result of your transactions or any other interaction with any such third parties.
 
 **3.5**    We use the minimum amount of cookies and similar tracking technologies to track the activity on our websites and hold certain information. Cookies are files with a small amount of data which may include an anonymous unique identifier. Cookies are sent to your browser from a website and stored on your device. Tracking technologies also used are beacons, tags, and scripts to collect and track information and to improve and analyze our services. You can instruct your browser to refuse all cookies or to indicate when a cookie is being sent. However, if you do not accept cookies, you may not be able to use some portions of our services.
 
@@ -81,13 +79,13 @@ Predictoor Portal Terms and Conditions (this “**Agreement**”) is made and en
 
 **4.2**    Customer will ensure that published assets and Customer and End Users’ use of published assets or the Predictoor Portal will not violate any of the Policies or any applicable law. The Customer is solely responsible for the development, content, operation, maintenance, and use of published assets.
 
-**4.3**    Where Customer permits, assists or facilitates such action, Customer will be deemed to have taken any action by any person or entity related to this Agreement, published assets or use of the Predictoor Stack. Customer is responsible for End Users’ use of published assets and the Ocean Market. Customer will ensure that all End Users comply with obligations mirroring those of Customer under this Agreement and that the terms of Customer’s agreements with each End User are consistent with this Agreement. If Customer becomes aware of any violation of Customer’s obligations under this Agreement caused by an End User, Customer will immediately suspend access to published assets and the Predictoor Stack by such End User. Ocean does not provide any support or services to End Users, unless Ocean has a separate agreement with Customer or an End User obligating Ocean to provide such support or services.
+**4.3**    Where Customer permits, assists or facilitates such action, Customer will be deemed to have taken any action by any person or entity related to this Agreement, published assets or use of the Predictoor Portal. Customer is responsible for End Users’ use of published assets and the Ocean Market. Customer will ensure that all End Users comply with obligations mirroring those of Customer under this Agreement and that the terms of Customer’s agreements with each End User are consistent with this Agreement. If Customer becomes aware of any violation of Customer’s obligations under this Agreement caused by an End User, Customer will immediately suspend access to published assets and the Predictoor Portal by such End User. Ocean does not provide any support or services to End Users, unless Ocean has a separate agreement with Customer or an End User obligating Ocean to provide such support or services.
 
 **5 FEES, PAYMENT**
 
 **5.1**    If you elect to purchase, submit, or trade through the use of predictions on the Predictoor Portal, it will be conducted solely through the Oasis network via MetaMask (or other Oasis-compatible wallets, browsers, or software). We will have no insight into or control over these payments or transactions, nor do we have the ability to reverse any transactions. With that in mind, we will have no liability to you or to any third party for any claims or damages that may arise as a result of any transactions that you engage in via the App, or using the Smart Contracts, or any other transactions that you conduct via the Oasis network, MetaMask, or another service.
 
-**5.2**    Oasis requires the payment of a transaction fee (a “Gas Fee”) for every transaction that occurs on the Oasis network. The Gas Fee funds the network of computers that run the decentralized Oasis network. This means that you will need to pay a Gas Fee for each transaction that occurs via the Predictoor Stack. In addition to the Gas Fee, we have hardcoded 0.1% of the total value of the transaction for the Ocean Protocol community development fund.
+**5.2**    Oasis requires the payment of a transaction fee (a “Gas Fee”) for every transaction that occurs on the Oasis network. The Gas Fee funds the network of computers that run the decentralized Oasis network. This means that you will need to pay a Gas Fee for each transaction that occurs via the Predictoor Portal. In addition to the Gas Fee, we have hardcoded 0.1% of the total value of the transaction for the Ocean Protocol community development fund.
 
 Customer acknowledges and agrees that the Commission will be transferred directly to the Ocean Protocol community development fund through the Ethereum network as part of any transactions or payments. 
 

--- a/resources/terms.md
+++ b/resources/terms.md
@@ -35,7 +35,7 @@ Predictoor Portal Terms and Conditions (this “**Agreement**”) is made and en
 
 “**Service**” means each of the websites, software and services made available by Ocean or its affiliates, including those web services described in the Service Terms. Services do not include Third-Party Content.
 
-“**Service Terms**” means the rights and restrictions for particular Services located on the Predictoor Website, or the Predictoor Stack (and any successor or related locations designated by Ocean), as may be updated by Ocean from time to time.
+“**Service Terms**” means the rights and restrictions for particular Services located on the Predictoor Website (and any successor or related locations designated by Ocean), as may be updated by Ocean from time to time.
 
 “**Website Terms**” means the terms of use located at [https://www.oceanprotocol.com (](https://www.oceanprotocol.com) (and any successor or related locations designated by Ocean), as may be updated by Ocean from time to time.
 

--- a/resources/terms.md
+++ b/resources/terms.md
@@ -1,0 +1,161 @@
+---
+title: Terms and Conditions
+description: Thanks for using our product and services.
+---
+
+Predictoor Terms and Conditions (this “**Agreement**”) is made and entered into by and between Ocean Protocol Foundation Ltd., with office at The Commerze @ Irving, 1 Irving Place, #08-11, Singapore, 369546 Singapore (“**Ocean**”) and the legal entity set forth in the Account Information (“**Customer**”). It governs Customer’s access to and use of the Predictoor Portal, Predictoor Feeds, and Predictoor Stack (as defined below) and takes effect on the date of its acceptance by Customer (the “**Effective Date**”). Customer represents being lawfully able to enter into contracts and having legal authority to bind Customer’s entity.
+
+**DEFINITIONS**
+
+“**API**” means an application program interface.
+
+“**Customer**” means any individual or entity that directly or indirectly through another user: (a) accesses or uses the Predictoor Portal; or (b) accesses or purchases published Predictoor Feeds; or (c) accesses or utilizes the Services provided.
+
+“**Trader**” means any Customer or legal entity and its employees that sources or intends to source external predictions, or utilize the Services provided.
+
+“**Predictoor**” means any Customer or legal entity and its employees that provides or intends to provide predictions, or utilize the Services provided.
+
+“**Documentation**” means the user guides (in each case exclusive of content referenced via hyperlink) for Predictoor, as such user guides may be updated by Ocean from time to time.
+
+“**Predictoor Portal**” means the website at https://predictoor.ai or https://test.predictoor.ai (and any successor or related site designated by Ocean), as may be updated by Ocean from time to time.
+
+“**Predictoor Feeds**” means the prediction feeds that Customers may purchase through Predictoor Portal, Services (and any successor or related site designated by Ocean), as may be updated by Ocean from time to time.
+
+“**Predictoor DF**” means the incentive emissions operated by Ocean to reward Predictoors for helping to provide accurate predictions.
+
+"**Predictoor Stack**" means the Documentation, Predictoor Portal, Predictoor Feeds, Predictoor DF, and Services listed herein that the Customer can access and use in accordance with this Agreement.
+
+“**Modifications Effective Date**” will have the meaning as set out in Section 2.2.
+
+“**Policies**” means the Privacy Policy, the Platform Terms, the Service Terms, all restrictions described in the Ocean Website, Predictoor Portal, Predictoor Stack and any other policy or terms referenced in or incorporated into this Agreement, but does not include whitepapers or other marketing materials referenced on the Ocean Website.
+
+“**Privacy Policy**” means the privacy policy located at https://www.oceanprotocol.com (and any successor or related locations designated by Ocean), as it may be updated by Ocean from time to time.
+
+“**Allowlist**” means a state in which Ocean allows specific Predictoor Feeds to be visible in the Predictoor Portal and elligible for Predictoor DF rewards. The Allowlist is an artifact of Ocean deploying Predictoor Feeds that are considered official. The Predictoor Portal Allowlist can be accessed here: https://github.com/oceanprotocol/pdr-web/blob/main/src/utils/config.ts
+
+“**Service**” means each of the websites, software and services made available by Ocean or its affiliates, including those web services described in the Service Terms. Services do not include Third-Party Content.
+
+“**Service Terms**” means the rights and restrictions for particular Services located on the Predictoor Portal, Ocean subgraphs [https://v4.subgraph.sapphire-mainnet.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph](https://v4.subgraph.sapphire-mainnet.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph), Ocean github repositories [https://github.com/oceanprotocol](https://github.com/oceanprotocol), (and any successor or related locations designated by Ocean), as may be updated by Ocean from time to time.
+
+“**Website Terms**” means the terms of use located at [https://predictoor.ai](https://predictoor.ai) or [https://test.predictoor.ai](https://test.predictoor.ai) (and any successor or related locations designated by Ocean), as may be updated by Ocean from time to time.
+
+“**Term**” means the term of this Agreement described in Section 7.1.
+
+“**Termination Date**” means the effective date of termination provided in accordance with Section 7.1.
+
+**1 ACCESS TO AND USE OF THE PLATFORM SERVICES**
+
+**1.1**    The Customer can access and use Predictoor Portal, Predictoor Feeds, Ocean Subgraphs, and Services in accordance with this Agreement. Customer undertakes to comply with the terms of this Agreement and all laws, rules and regulations applicable to Customer’s use of the Predictoor Stack.
+
+**1.2**    To access Predictoor Feeds and to participate as a Predictoor, Customer must have a Web3 wallet (e.g. MetaMask) and must have Ocean tokens in their wallet.
+
+**1.3**    The Predictoor Stack connects Predictoors and Traders directly, without any 3rd party control via the Predictoor Portal. This means that while providing predictions as a Predictoor, Customers are responsible for their own activity. This also means that while purchasing Prediction Feeds as a Trader, Customers are responsible for their own activity. Customers must adhere to the laws in their own legal jurisdiction as well as their conscience. Ocean is not responsible for any malicious use of the Predictoor Stack or any losses associated with the use of the Predictoor Stack of any source.  
+
+**1.4**    By clicking any button or box marked “accept” or “agree” (or a similar term) in connection with this Agreement, or by accessing or using the Predictoor Stack, you agree to be bound by this Agreement, a current version of which is available at the Predictoor Portal, and which may be modified from time to time at our sole discretion. We are only providing our services if you accept all of these terms. By using the Predictoor Stack, the Customer confirms their understanding and agrees to be bound by all of these terms. If Customer accepts these terms on behalf of a company or other legal entity, Customer represents that they have the legal authority to accept these terms on that entity’s behalf, in which case Customer will mean that entity.  If Customer does not accept all of these terms, then you may not access or use the Predictoor Stack.  
+
+**2 MODIFICATIONS**
+
+**2.1**    Ocean may modify this Agreement, change or discontinue any Service (including any policies and Service Level Agreements) at any time with no prior notification  Ocean will provide 15 days advance notice prior to the effective date of software modifications (“**Modifications Effective Date**”).
+
+**2.2**    If Customer continues to use the Predictoor Stack after the Modifications Effective Date, Customer will be deemed to be bound by the modified terms as of the Modifications Effective Date.
+
+**2.3**	    If Customer objects to the software modifications , the Customer may cease to use the Predictoor Stack.
+
+**3 SECURITY – DATA PROTECTION**
+
+**3.1**     Without limiting Customer obligations under Section 4.2, Ocean has implemented reasonable and appropriate measures designed to help Predictoors submit predictions privately through the use of Oasis Sapphire, against accidental or unlawful loss, access or disclosure.
+
+**3.2**    Predictions submitted are stored and computed privately on-chain. Ocean does not store any information.
+
+**3.3**    Transactions that take place on the Predictoor Stack are managed and confirmed via the Oasis blockchain. Your wallet public address will be made publicly visible whenever you engage in a transaction on the Predictoor Stack.
+
+**3.4**    We neither own nor control MetaMask, Coinbase, Celr, Google Chrome, the Oasis network, or any other third parties site, product, or service that you might access, visit, or use for the purpose of enabling you to use the various features of the Predictoor Stack. We will not be liable for the acts or omissions of any such third parties, nor will we be liable for any damage that you may suffer as a result of your transactions or any other interaction with any such third parties.
+
+**3.5**    We use the minimum amount of cookies and similar tracking technologies to track the activity on our websites and hold certain information. Cookies are files with a small amount of data which may include an anonymous unique identifier. Cookies are sent to your browser from a website and stored on your device. Tracking technologies also used are beacons, tags, and scripts to collect and track information and to improve and analyze our services. You can instruct your browser to refuse all cookies or to indicate when a cookie is being sent. However, if you do not accept cookies, you may not be able to use some portions of our services.
+
+**3.6**    The security of your data is important to us, but remember that no method of transmission over the Internet, or method of electronic storage is 100% secure. While we strive to use commercially acceptable means to protect your Personal Data, we cannot guarantee its absolute security and we do not take any liability in case of security breaches.
+
+**4 CUSTOMER’S RESPONSIBILITIES**
+
+**4.1**    Customer is responsible for all activities, regardless of whether the activities are authorized by Customer or undertaken by Customer, Customer’s employees or a third party (including Customer’s contractors, agents or End Users). Ocean and its affiliates are not responsible for unauthorized access to Customer Account.
+
+**4.2**    Customer will ensure that published assets and Customer and End Users’ use of published assets or the Predictoor Stack will not violate any of the Policies or any applicable law. The Customer is solely responsible for the development, content, operation, maintenance, and use of published assets.
+
+**4.3**    Where Customer permits, assists or facilitates such action, Customer will be deemed to have taken any action by any person or entity related to this Agreement, published assets or use of the Predictoor Stack. Customer is responsible for End Users’ use of published assets and the Ocean Market. Customer will ensure that all End Users comply with obligations mirroring those of Customer under this Agreement and that the terms of Customer’s agreements with each End User are consistent with this Agreement. If Customer becomes aware of any violation of Customer’s obligations under this Agreement caused by an End User, Customer will immediately suspend access to published assets and the Predictoor Stack by such End User. Ocean does not provide any support or services to End Users, unless Ocean has a separate agreement with Customer or an End User obligating Ocean to provide such support or services.
+
+**5 FEES, PAYMENT**
+
+**5.1**    If you elect to purchase, submit, or trade through the user of predictions on the Predictoor Stack, it will be conducted solely through the Oasis network via MetaMask (or other Oasis-compatible wallets, browsers, or software). We will have no insight into or control over these payments or transactions, nor do we have the ability to reverse any transactions. With that in mind, we will have no liability to you or to any third party for any claims or damages that may arise as a result of any transactions that you engage in via the App, or using the Smart Contracts, or any other transactions that you conduct via the Oasis network, MetaMask, or another service.
+
+**5.2**    Oasis requires the payment of a transaction fee (a “Gas Fee”) for every transaction that occurs on the Oasis network. The Gas Fee funds the network of computers that run the decentralized Oasis network. This means that you will need to pay a Gas Fee for each transaction that occurs via the Predictoor Stack. In addition to the Gas Fee, we have hardcoded 0.1% of the total value of the transaction for the Ocean Protocol community development fund.
+
+Customer acknowledges and agrees that the Commission will be transferred directly to the Ocean Protocol community development fund through the Ethereum network as part of any transactions or payments. 
+
+**5.3**    Each Party will be responsible, as required under applicable law, for identifying and paying all taxes and other governmental fees and charges (and any penalties, interest, and other additions thereto) that are imposed on that Party upon or with respect to the transactions and payments under this Agreement.
+
+**6 SUSPENSION**
+
+**6.1**	Ocean may suspend Customer or any End User’s right to access or use any portion or all of the Predictoor Portal or Services immediately with no notice to Customer if Ocean determines that the Customer or an End User’s use of the Predictoor Stack:
+
+(b) poses a security risk to the Predictoor Stack or any third party,
+
+(c) could adversely impact Ocean systems, the Predictoor Stack or the systems or Content of any other Ocean customer,
+
+(d) could subject Ocean, Ocean affiliates, or any third party to liability, and/or
+
+(e) could be fraudulent;
+
+(f) Customer or any End User is in breach of this Agreement; or
+
+(g) Customer has ceased to operate in the ordinary course, made an assignment for the benefit of creditors or similar disposition of Customer assets, or become the subject of any bankruptcy, reorganization, liquidation, dissolution or similar proceeding.
+
+**6.2**	If Ocean, according to Section 6.1, suspends Customer’s right to access or use any portion or all of the Predictoor Stack:
+
+(a) Customer remains responsible for all fees and charges Customer incurs during the period of suspension; and
+
+(b) Customer will not be entitled to any service credits under the Service Level Agreements for any period of suspension.
+
+## TODO
+**7 PURGATORY & TERMINATION**
+
+**7.1**	Purgatory is a state in which a publisher or data asset is tagged as "in purgatory". Being in purgatory has implications into how the asset is displayed in Ocean Market, and what actions are permitted to be performed on the asset. Once in purgatory, the asset or publisher may stay there or leave purgatory if certain conditions are fulfilled. 
+
+**7.2**	This agreement can be terminated at any time by discontinuing Customer access to and use of the Predictoor Stack. You will not receive any refunds, you agree that we, in our sole discretion and for any or no reason, may terminate these Terms and suspend and/or terminate the access to the Predictoor Stack and that we will not be liable to you or to any third party for any such suspension or termination.
+
+**8 INTELLECTUAL PROPERTY RIGHTS AND LICENSE**
+
+**8.1**    Except as provided in this Section 8, Ocean obtains no rights whatsoever under this Agreement from Customer (or Customer’s licensors) to published assets.
+
+**8.2**    Customer represents and warrants to Ocean that:
+
+(a) Customer or Customer’s licensors own all right, title, and interest in and of the published assets and
+
+(b) Customer has all rights in published assets necessary to grant the rights contemplated by this Agreement.
+
+**8.3**    Subject to the terms of this Agreement, Ocean grants Customer a limited, revocable, non-exclusive, non-sublicensable, non-transferable license to access and use the Predictoor Stack solely in accordance with this Agreement.
+
+**8.4**    Except as provided in Section 8.3, the Customer obtains no rights under this Agreement from Ocean, Ocean affiliates or Ocean licensors to the Predictoor Stack, including any related intellectual property rights.
+
+**8.5**	Ocean Content and Third-Party Content may be provided to the Customer under a separate agreement and/or a separate license. In the event of a conflict between this Agreement and any separate agreement and/or separate license, the separate agreement and/or separate license will prevail with respect to the Ocean Content or Third-Party Content that is the subject of such separate agreement and/or separate license.
+
+**9 WARRANTIES; LIMITATIONS OF LIABILITY**
+
+**9.1**    Warranties. The Predictoor Stack is provided “as is”. Except to the extent prohibited by law, or to the extent any statutory rights apply that cannot be excluded, limited or waived, Ocean its affiliates and licensors:
+
+(a) make no representations or warranties of any kind, whether express, implied, statutory or otherwise regarding the service offerings or the Third-Party Content, and
+
+(b) disclaim all warranties, including any implied or express warranties
+
+(c) of merchantability, satisfactory quality, fitness for a particular purpose, non- infringement, or quiet enjoyment,
+
+(d) arising out of any course of dealing or usage of trade,
+
+(e) that any content will be secure or not otherwise lost or altered.
+
+**10 GOVERNING LAW**
+
+**10.1**	The laws of Singapore, without reference to conflict of law rules, govern this Agreement and any dispute of any sort that might arise between Customer and Ocean. The United Nations Convention for the International Sale of Goods does not apply to this Agreement.
+
+**10.2**	Any dispute arising from or in connection with this Agreement or the fulfilment thereof will be exclusively adjudicated in the Courts of Singapore and Customer consents to this exclusive jurisdiction and venue.
+
+**10.3**    Notwithstanding the foregoing Ocean and Customer both agree that Ocean may bring suit against Customer before the court at any of Customer’s business seats and/or at the court where any breach of this Agreement or infringement of Ocean rights occurred.

--- a/resources/terms.md
+++ b/resources/terms.md
@@ -63,9 +63,9 @@ Predictoor Portal Terms and Conditions (this “**Agreement**”) is made and en
 
 **3 SECURITY – DATA PROTECTION**
 
-**3.1**     Without limiting Customer obligations under Section 4.2, Ocean has implemented reasonable and appropriate measures designed to help Predictoors submit predictions privately through the use of Oasis Sapphire, against accidental or unlawful loss, access or disclosure.
+**3.1**     Without limiting Customer obligations under Section 4.2, Ocean will implement reasonable and appropriate measures designed to help Predictoors and Traders to secure published assets against accidental or unlawful loss, access or disclosure.
 
-**3.2**    Predictions submitted are stored and computed privately on-chain. Ocean does not store any information.
+**3.2**    Predictions submitted are stored and computed privately on-chain. Ocean does not store or have privilege to any information.
 
 **3.3**    Transactions that take place on the Predictoor Portal are managed and confirmed via the Oasis blockchain. Your wallet public address will be made publicly visible whenever you engage in a transaction on the Predictoor Portal.
 

--- a/resources/terms.md
+++ b/resources/terms.md
@@ -27,7 +27,7 @@ Predictoor Portal Terms and Conditions (this “**Agreement**”) is made and en
 
 “**Modifications Effective Date**” will have the meaning as set out in Section 2.2.
 
-“**Policies**” means the Privacy Policy, the Platform Terms, the Service Terms, all restrictions described in the Predictoor Website, Predictoor Portal, Predictoor Stack and any other policy or terms referenced in or incorporated into this Agreement, but does not include whitepapers or other marketing materials referenced on the Predictoor Website.
+“**Policies**” means the Privacy Policy, the Platform Terms, the Service Terms, all restrictions described in the Predictoor Website, and on the Predictoor Portal, and any other policy or terms referenced in or incorporated into this Agreement, but does not include whitepapers or other marketing materials referenced on the Predictoor Website.
 
 “**Privacy Policy**” means the privacy policy located at https://www.oceanprotocol.com (and any successor or related locations designated by Ocean), as it may be updated by Ocean from time to time.
 
@@ -35,7 +35,7 @@ Predictoor Portal Terms and Conditions (this “**Agreement**”) is made and en
 
 “**Service**” means each of the websites, software and services made available by Ocean or its affiliates, including those web services described in the Service Terms. Services do not include Third-Party Content.
 
-“**Service Terms**” means the rights and restrictions for particular Services located on the Predictoor Portal, or the Predictoor Stack (and any service or related locations designated by Ocean), as may be updated by Ocean from time to time.
+“**Service Terms**” means the rights and restrictions for particular Services located on the Predictoor Website, or the Predictoor Stack (and any successor or related locations designated by Ocean), as may be updated by Ocean from time to time.
 
 “**Website Terms**” means the terms of use located at [https://www.oceanprotocol.com (](https://www.oceanprotocol.com) (and any successor or related locations designated by Ocean), as may be updated by Ocean from time to time.
 
@@ -45,21 +45,21 @@ Predictoor Portal Terms and Conditions (this “**Agreement**”) is made and en
 
 **1 ACCESS TO AND USE OF THE PLATFORM SERVICES**
 
-**1.1**    The Customer can access and use Predictoor Portal, Predictoor Feeds, Ocean Subgraphs, and Services in accordance with this Agreement. Customer undertakes to comply with the terms of this Agreement and all laws, rules and regulations applicable to Customer’s use of the Predictoor Stack.
+**1.1**    The Customer can access and use Predictoor Portal and Services in accordance with this Agreement. Customer undertakes to comply with the terms of this Agreement and all laws, rules and regulations applicable to Customer’s use of the Predictoor Portal.
 
 **1.2**    To access Predictoor Feeds and to participate as a Predictoor, the Customer must have a Web3 wallet (e.g. MetaMask) and must have Ocean tokens in their wallet.
 
-**1.3**    The Predictoor Stack connects Predictoors and Traders directly, without any 3rd party control via the Predictoor Portal. This means that while providing predictions as a Predictoor, Customers are responsible for their own activity. This means that while purchasing Prediction Feeds as a Trader, Customers are responsible for their own activity. Customers must adhere to the laws in their own legal jurisdiction as well as their conscience. Ocean is not responsible for any malicious use of the Predictoor Stack or any losses associated with the use of the Predictoor Stack of any source.  
+**1.3**    The Predictoor Portal connects Predictoors and Traders directly, without any 3rd party control via the Predictoor Portal. This means that while providing predictions as a Predictoor, Customers are responsible for their own activity. This means that while purchasing Prediction Feeds as a Trader, Customers are responsible for their own activity. Customers must adhere to the laws in their own legal jurisdiction as well as their conscience. Ocean is not responsible for any malicious use of the Predictoor Stack or any losses associated with the use of the Predictoor Stack or any source.  
 
-**1.4**    By clicking any button or box marked “accept” or “agree” (or a similar term) in connection with this Agreement, or by accessing or using the Predictoor Stack, you agree to be bound by this Agreement, a current version of which is available at the Predictoor Portal, and which may be modified from time to time at our sole discretion. We are only providing our services if you accept all of these terms. By using the Predictoor Stack, the Customer confirms their understanding and agrees to be bound by all of these terms. If Customer accepts these terms on behalf of a company or other legal entity, Customer represents that they have the legal authority to accept these terms on that entity’s behalf, in which case Customer will mean that entity.  If Customer does not accept all of these terms, then you may not access or use the Predictoor Stack.  
+**1.4**    By clicking any button or box marked “accept” or “agree” (or a similar term) in connection with this Agreement, or by accessing or using the Predictoor Portal, you agree to be bound by this Agreement, a current version of which is available at the Predictoor Portal, and which may be modified from time to time at our sole discretion. We are only providing our services if you accept all of these terms. By using the Predictoor Portal, the Customer confirms their understanding and agrees to be bound by all of these terms. If Customer accepts these terms on behalf of a company or other legal entity, Customer represents that they have the legal authority to accept these terms on that entity’s behalf, in which case Customer will mean that entity.  If Customer does not accept all of these terms, then you may not access or use the Predictoor Portal.  
 
 **2 MODIFICATIONS**
 
 **2.1**    Ocean may modify this Agreement, change or discontinue any Service (including any policies and Service Level Agreements) at any time with no prior notification  Ocean will provide 15 days advance notice prior to the effective date of software modifications (“**Modifications Effective Date**”).
 
-**2.2**    If Customer continues to use the Predictoor Stack after the Modifications Effective Date, Customer will be deemed to be bound by the modified terms as of the Modifications Effective Date.
+**2.2**    If Customer continues to use the Predictoor Portal after the Modifications Effective Date, Customer will be deemed to be bound by the modified terms as of the Modifications Effective Date.
 
-**2.3**	    If Customer objects to the software modifications , the Customer may cease to use the Predictoor Stack.
+**2.3**	    If Customer objects to the software modifications , the Customer may cease to use the Predictoor Portal.
 
 **3 SECURITY – DATA PROTECTION**
 
@@ -67,7 +67,7 @@ Predictoor Portal Terms and Conditions (this “**Agreement**”) is made and en
 
 **3.2**    Predictions submitted are stored and computed privately on-chain. Ocean does not store any information.
 
-**3.3**    Transactions that take place on the Predictoor Stack are managed and confirmed via the Oasis blockchain. Your wallet public address will be made publicly visible whenever you engage in a transaction on the Predictoor Stack.
+**3.3**    Transactions that take place on the Predictoor Portal are managed and confirmed via the Oasis blockchain. Your wallet public address will be made publicly visible whenever you engage in a transaction on the Predictoor Portal.
 
 **3.4**    We neither own nor control MetaMask, Coinbase, Celr, Google Chrome, the Oasis network, or any other third parties site, product, or service that you might access, visit, or use for the purpose of enabling you to use the various features of the Predictoor Stack. We will not be liable for the acts or omissions of any such third parties, nor will we be liable for any damage that you may suffer as a result of your transactions or any other interaction with any such third parties.
 
@@ -79,13 +79,13 @@ Predictoor Portal Terms and Conditions (this “**Agreement**”) is made and en
 
 **4.1**    Customer is responsible for all activities, regardless of whether the activities are authorized by Customer or undertaken by Customer, Customer’s employees or a third party (including Customer’s contractors, agents or End Users). Ocean and its affiliates are not responsible for unauthorized access to Customer Account.
 
-**4.2**    Customer will ensure that published assets and Customer and End Users’ use of published assets or the Predictoor Stack will not violate any of the Policies or any applicable law. The Customer is solely responsible for the development, content, operation, maintenance, and use of published assets.
+**4.2**    Customer will ensure that published assets and Customer and End Users’ use of published assets or the Predictoor Portal will not violate any of the Policies or any applicable law. The Customer is solely responsible for the development, content, operation, maintenance, and use of published assets.
 
 **4.3**    Where Customer permits, assists or facilitates such action, Customer will be deemed to have taken any action by any person or entity related to this Agreement, published assets or use of the Predictoor Stack. Customer is responsible for End Users’ use of published assets and the Ocean Market. Customer will ensure that all End Users comply with obligations mirroring those of Customer under this Agreement and that the terms of Customer’s agreements with each End User are consistent with this Agreement. If Customer becomes aware of any violation of Customer’s obligations under this Agreement caused by an End User, Customer will immediately suspend access to published assets and the Predictoor Stack by such End User. Ocean does not provide any support or services to End Users, unless Ocean has a separate agreement with Customer or an End User obligating Ocean to provide such support or services.
 
 **5 FEES, PAYMENT**
 
-**5.1**    If you elect to purchase, submit, or trade through the user of predictions on the Predictoor Stack, it will be conducted solely through the Oasis network via MetaMask (or other Oasis-compatible wallets, browsers, or software). We will have no insight into or control over these payments or transactions, nor do we have the ability to reverse any transactions. With that in mind, we will have no liability to you or to any third party for any claims or damages that may arise as a result of any transactions that you engage in via the App, or using the Smart Contracts, or any other transactions that you conduct via the Oasis network, MetaMask, or another service.
+**5.1**    If you elect to purchase, submit, or trade through the use of predictions on the Predictoor Portal, it will be conducted solely through the Oasis network via MetaMask (or other Oasis-compatible wallets, browsers, or software). We will have no insight into or control over these payments or transactions, nor do we have the ability to reverse any transactions. With that in mind, we will have no liability to you or to any third party for any claims or damages that may arise as a result of any transactions that you engage in via the App, or using the Smart Contracts, or any other transactions that you conduct via the Oasis network, MetaMask, or another service.
 
 **5.2**    Oasis requires the payment of a transaction fee (a “Gas Fee”) for every transaction that occurs on the Oasis network. The Gas Fee funds the network of computers that run the decentralized Oasis network. This means that you will need to pay a Gas Fee for each transaction that occurs via the Predictoor Stack. In addition to the Gas Fee, we have hardcoded 0.1% of the total value of the transaction for the Ocean Protocol community development fund.
 
@@ -95,11 +95,11 @@ Customer acknowledges and agrees that the Commission will be transferred directl
 
 **6 SUSPENSION**
 
-**6.1**    Ocean may suspend Customer or any End User’s right to access or use any portion or all of the Predictoor Stack, or immediately with no notice to Customer if Ocean determines that the Customer or an End User’s use of the Predictoor Stack:
+**6.1**    Ocean may suspend Customer or any End User’s right to access or use any portion or all of the Predictoor Portal, or immediately with no notice to Customer if Ocean determines that the Customer or an End User’s use of the Predictoor Portal:
 
-(b) poses a security risk to the Predictoor Stack or any third party,
+(b) poses a security risk to the Predictoor Portal or any third party,
 
-(c) could adversely impact Ocean systems, the Predictoor Stack or the systems or Content of any other Ocean customer,
+(c) could adversely impact Ocean systems, the Predictoor Portal, or the systems or Content of any other Ocean customer,
 
 (d) could subject Ocean, Ocean affiliates, or any third party to liability, and/or
 
@@ -109,7 +109,7 @@ Customer acknowledges and agrees that the Commission will be transferred directl
 
 (g) Customer has ceased to operate in the ordinary course, made an assignment for the benefit of creditors or similar disposition of Customer assets, or become the subject of any bankruptcy, reorganization, liquidation, dissolution or similar proceeding.
 
-**6.2**    If Ocean, according to Section 6.1, suspends Customer’s right to access or use any portion or all of the Predictoor Stack:
+**6.2**    If Ocean, according to Section 6.1, suspends Customer’s right to access or use any portion or all of the Predictoor Portal:
 
 (a) Customer remains responsible for all fees and charges Customer incurs during the period of suspension; and
 
@@ -119,7 +119,7 @@ Customer acknowledges and agrees that the Commission will be transferred directl
 
 **7.1**    Allowlist is a state in which a Predictoor Feed is tagged as "allowed". Being allow has implications into how the asset is displayed in the Predictoor Portal, and whether the asset is incentivized by Predictoor DF.
 
-**7.2**    This agreement can be terminated at any time by discontinuing Customer access to and use of the Predictoor Stack. You will not receive any refunds, you agree that we, in our sole discretion and for any or no reason, may terminate these Terms and suspend and/or terminate the access to the Predictoor Stack and that we will not be liable to you or to any third party for any such suspension or termination.
+**7.2**    This agreement can be terminated at any time by discontinuing Customer access to and use of the Predictoor Portal. You will not receive any refunds, you agree that we, in our sole discretion and for any or no reason, may terminate these Terms and suspend and/or terminate the access to the Predictoor Portal and that we will not be liable to you or to any third party for any such suspension or termination.
 
 **8 INTELLECTUAL PROPERTY RIGHTS AND LICENSE**
 
@@ -131,15 +131,15 @@ Customer acknowledges and agrees that the Commission will be transferred directl
 
 (b) Customer has all rights in published assets necessary to grant the rights contemplated by this Agreement.
 
-**8.3**    Subject to the terms of this Agreement, Ocean grants Customer a limited, revocable, non-exclusive, non-sublicensable, non-transferable license to access and use the Predictoor Stack solely in accordance with this Agreement.
+**8.3**    Subject to the terms of this Agreement, Ocean grants Customer a limited, revocable, non-exclusive, non-sublicensable, non-transferable license to access and use the Predictoor Portal solely in accordance with this Agreement.
 
-**8.4**    Except as provided in Section 8.3, the Customer obtains no rights under this Agreement from Ocean, Ocean affiliates or Ocean licensors to the Predictoor Stack, including any related intellectual property rights.
+**8.4**    Except as provided in Section 8.3, the Customer obtains no rights under this Agreement from Ocean, Ocean affiliates or Ocean licensors to the Predictoor Portal, including any related intellectual property rights.
 
 **8.5**    Ocean Content and Third-Party Content may be provided to the Customer under a separate agreement and/or a separate license. In the event of a conflict between this Agreement and any separate agreement and/or separate license, the separate agreement and/or separate license will prevail with respect to the Ocean Content or Third-Party Content that is the subject of such separate agreement and/or separate license.
 
 **9 WARRANTIES; LIMITATIONS OF LIABILITY**
 
-**9.1**    Warranties. The Predictoor Stack is provided “as is”. Except to the extent prohibited by law, or to the extent any statutory rights apply that cannot be excluded, limited or waived, Ocean its affiliates and licensors:
+**9.1**    Warranties. The Predictoor Portal is provided “as is”. Except to the extent prohibited by law, or to the extent any statutory rights apply that cannot be excluded, limited or waived, Ocean its affiliates and licensors:
 
 (a) make no representations or warranties of any kind, whether express, implied, statutory or otherwise regarding the service offerings or the Third-Party Content, and
 

--- a/resources/terms.md
+++ b/resources/terms.md
@@ -115,7 +115,7 @@ Customer acknowledges and agrees that the Commission will be transferred directl
 
 **7 ALLOWLIST & TERMINATION**
 
-**7.1**    Allowlist is a state in which a Predictoor Feed is tagged as "allowed". Being allow has implications into how the asset is displayed in the Predictoor Portal, and whether the asset is incentivized by Predictoor DF.
+**7.1**    Allowlist is a state in which a Predictoor Feed is tagged as "allowed". Being allow has implications into how the asset is displayed in the Predictoor Portal, and whether the asset qualifies for Predictoor DF rewards.
 
 **7.2**    This agreement can be terminated at any time by discontinuing Customer access to and use of the Predictoor Portal. You will not receive any refunds, you agree that we, in our sole discretion and for any or no reason, may terminate these Terms and suspend and/or terminate the access to the Predictoor Portal and that we will not be liable to you or to any third party for any such suspension or termination.
 

--- a/resources/terms.md
+++ b/resources/terms.md
@@ -3,41 +3,41 @@ title: Terms and Conditions
 description: Thanks for using our product and services.
 ---
 
-Predictoor Terms and Conditions (this “**Agreement**”) is made and entered into by and between Ocean Protocol Foundation Ltd., with office at The Commerze @ Irving, 1 Irving Place, #08-11, Singapore, 369546 Singapore (“**Ocean**”) and the legal entity set forth in the Account Information (“**Customer**”). It governs Customer’s access to and use of the Predictoor Portal, Predictoor Feeds, and Predictoor Stack (as defined below) and takes effect on the date of its acceptance by Customer (the “**Effective Date**”). Customer represents being lawfully able to enter into contracts and having legal authority to bind Customer’s entity.
+Predictoor Portal Terms and Conditions (this “**Agreement**”) is made and entered into by and between Ocean Protocol Foundation Ltd., with office at The Commerze @ Irving, 1 Irving Place, #08-11, Singapore, 369546 Singapore (“**Ocean**”) and the legal entity set forth in the Account Information (“**Customer**”). It governs Customer’s access to and use of the Predictoor Portal, Predictoor Feeds, and Predictoor Stack (as defined below) and takes effect on the date of its acceptance by Customer (the “**Effective Date**”). Customer represents being lawfully able to enter into contracts and having legal authority to bind Customer’s entity.
 
 **DEFINITIONS**
 
 “**API**” means an application program interface.
 
-“**Customer**” means any individual or entity that directly or indirectly through another user: (a) accesses or uses the Predictoor Portal; or (b) accesses or purchases published Predictoor Feeds; or (c) accesses or utilizes the Services provided.
+“**Customer**” means any individual or entity that directly or indirectly through another user: (a) accesses or uses the Predictoor Portal; or (b) accesses or purchases Predictoor Feeds; or (c) accesses or utilizes the Predictoor Stack.
 
 “**Trader**” means any Customer or legal entity and its employees that sources or intends to source external predictions, or utilize the Services provided.
 
 “**Predictoor**” means any Customer or legal entity and its employees that provides or intends to provide predictions, or utilize the Services provided.
 
-“**Documentation**” means the user guides (in each case exclusive of content referenced via hyperlink) for Predictoor, as such user guides may be updated by Ocean from time to time.
+“**Documentation**” means the user guides (in each case exclusive of content referenced via hyperlink) for the Predictoor Stack, as such user guides may be updated by Ocean from time to time.
 
-“**Predictoor Portal**” means the website at https://predictoor.ai or https://test.predictoor.ai (and any successor or related site designated by Ocean), as may be updated by Ocean from time to time.
+“**Predictoor Website**” means the website at https://predictoor.ai or https://test.predictoor.ai (and any successor or related sites designated by Ocean), as may be updated by Ocean from time to time.
 
-“**Predictoor Feeds**” means the prediction feeds that Customers may purchase through Predictoor Portal, Services (and any successor or related site designated by Ocean), as may be updated by Ocean from time to time.
+“**Predictoor Feeds**” means the prediction feeds that Customers may purchase through Predictoor Portal, or the Predictoor Stack (and any successor or distribution channels designated by Ocean), as may be updated by Ocean from time to time.
 
-“**Predictoor DF**” means the incentive emissions operated by Ocean to reward Predictoors for helping to provide accurate predictions.
+"**Predictoor Stack**" means the Predictoor Portal, Predictoor Feeds, Services, and Predictoor DF listed herein (and any successor or related technologies designated by Ocean) that the Customer can access and use in accordance with this Agreement.
 
-"**Predictoor Stack**" means the Documentation, Predictoor Portal, Predictoor Feeds, Predictoor DF, and Services listed herein that the Customer can access and use in accordance with this Agreement.
+“**Predictoor DF**” means the incentive emissions operated by Ocean to reward Predictoors for helping to provide accurate predictions, (and any successor or parameter updates designated by Ocean), as may be updated by Ocean from time to time.
 
 “**Modifications Effective Date**” will have the meaning as set out in Section 2.2.
 
-“**Policies**” means the Privacy Policy, the Platform Terms, the Service Terms, all restrictions described in the Ocean Website, Predictoor Portal, Predictoor Stack and any other policy or terms referenced in or incorporated into this Agreement, but does not include whitepapers or other marketing materials referenced on the Ocean Website.
+“**Policies**” means the Privacy Policy, the Platform Terms, the Service Terms, all restrictions described in the Predictoor Website, Predictoor Portal, Predictoor Stack and any other policy or terms referenced in or incorporated into this Agreement, but does not include whitepapers or other marketing materials referenced on the Predictoor Website.
 
 “**Privacy Policy**” means the privacy policy located at https://www.oceanprotocol.com (and any successor or related locations designated by Ocean), as it may be updated by Ocean from time to time.
 
-“**Allowlist**” means a state in which Ocean allows specific Predictoor Feeds to be visible in the Predictoor Portal and elligible for Predictoor DF rewards. The Allowlist is an artifact of Ocean deploying Predictoor Feeds that are considered official. The Predictoor Portal Allowlist can be accessed here: https://github.com/oceanprotocol/pdr-web/blob/main/src/utils/config.ts
+“**Allowlist**” means a state in which Ocean tags specific Predictoor Feeds to be visible in the Predictoor Portal and elligible for Predictoor DF rewards. The Allowlist is an artifact of Ocean deploying Predictoor Feeds which are considered officially supported. The Predictoor Portal Allowlist can be accessed here: https://github.com/oceanprotocol/pdr-web/blob/main/src/utils/config.ts
 
 “**Service**” means each of the websites, software and services made available by Ocean or its affiliates, including those web services described in the Service Terms. Services do not include Third-Party Content.
 
-“**Service Terms**” means the rights and restrictions for particular Services located on the Predictoor Portal, Ocean subgraphs [https://v4.subgraph.sapphire-mainnet.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph](https://v4.subgraph.sapphire-mainnet.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph), Ocean github repositories [https://github.com/oceanprotocol](https://github.com/oceanprotocol), (and any successor or related locations designated by Ocean), as may be updated by Ocean from time to time.
+“**Service Terms**” means the rights and restrictions for particular Services located on the Predictoor Portal, or the Predictoor Stack (and any service or related locations designated by Ocean), as may be updated by Ocean from time to time.
 
-“**Website Terms**” means the terms of use located at [https://predictoor.ai](https://predictoor.ai) or [https://test.predictoor.ai](https://test.predictoor.ai) (and any successor or related locations designated by Ocean), as may be updated by Ocean from time to time.
+“**Website Terms**” means the terms of use located at [https://www.oceanprotocol.com (](https://www.oceanprotocol.com) (and any successor or related locations designated by Ocean), as may be updated by Ocean from time to time.
 
 “**Term**” means the term of this Agreement described in Section 7.1.
 
@@ -47,9 +47,9 @@ Predictoor Terms and Conditions (this “**Agreement**”) is made and entered i
 
 **1.1**    The Customer can access and use Predictoor Portal, Predictoor Feeds, Ocean Subgraphs, and Services in accordance with this Agreement. Customer undertakes to comply with the terms of this Agreement and all laws, rules and regulations applicable to Customer’s use of the Predictoor Stack.
 
-**1.2**    To access Predictoor Feeds and to participate as a Predictoor, Customer must have a Web3 wallet (e.g. MetaMask) and must have Ocean tokens in their wallet.
+**1.2**    To access Predictoor Feeds and to participate as a Predictoor, the Customer must have a Web3 wallet (e.g. MetaMask) and must have Ocean tokens in their wallet.
 
-**1.3**    The Predictoor Stack connects Predictoors and Traders directly, without any 3rd party control via the Predictoor Portal. This means that while providing predictions as a Predictoor, Customers are responsible for their own activity. This also means that while purchasing Prediction Feeds as a Trader, Customers are responsible for their own activity. Customers must adhere to the laws in their own legal jurisdiction as well as their conscience. Ocean is not responsible for any malicious use of the Predictoor Stack or any losses associated with the use of the Predictoor Stack of any source.  
+**1.3**    The Predictoor Stack connects Predictoors and Traders directly, without any 3rd party control via the Predictoor Portal. This means that while providing predictions as a Predictoor, Customers are responsible for their own activity. This means that while purchasing Prediction Feeds as a Trader, Customers are responsible for their own activity. Customers must adhere to the laws in their own legal jurisdiction as well as their conscience. Ocean is not responsible for any malicious use of the Predictoor Stack or any losses associated with the use of the Predictoor Stack of any source.  
 
 **1.4**    By clicking any button or box marked “accept” or “agree” (or a similar term) in connection with this Agreement, or by accessing or using the Predictoor Stack, you agree to be bound by this Agreement, a current version of which is available at the Predictoor Portal, and which may be modified from time to time at our sole discretion. We are only providing our services if you accept all of these terms. By using the Predictoor Stack, the Customer confirms their understanding and agrees to be bound by all of these terms. If Customer accepts these terms on behalf of a company or other legal entity, Customer represents that they have the legal authority to accept these terms on that entity’s behalf, in which case Customer will mean that entity.  If Customer does not accept all of these terms, then you may not access or use the Predictoor Stack.  
 
@@ -95,7 +95,7 @@ Customer acknowledges and agrees that the Commission will be transferred directl
 
 **6 SUSPENSION**
 
-**6.1**	Ocean may suspend Customer or any End User’s right to access or use any portion or all of the Predictoor Portal or Services immediately with no notice to Customer if Ocean determines that the Customer or an End User’s use of the Predictoor Stack:
+**6.1**    Ocean may suspend Customer or any End User’s right to access or use any portion or all of the Predictoor Stack, or immediately with no notice to Customer if Ocean determines that the Customer or an End User’s use of the Predictoor Stack:
 
 (b) poses a security risk to the Predictoor Stack or any third party,
 
@@ -109,22 +109,21 @@ Customer acknowledges and agrees that the Commission will be transferred directl
 
 (g) Customer has ceased to operate in the ordinary course, made an assignment for the benefit of creditors or similar disposition of Customer assets, or become the subject of any bankruptcy, reorganization, liquidation, dissolution or similar proceeding.
 
-**6.2**	If Ocean, according to Section 6.1, suspends Customer’s right to access or use any portion or all of the Predictoor Stack:
+**6.2**    If Ocean, according to Section 6.1, suspends Customer’s right to access or use any portion or all of the Predictoor Stack:
 
 (a) Customer remains responsible for all fees and charges Customer incurs during the period of suspension; and
 
 (b) Customer will not be entitled to any service credits under the Service Level Agreements for any period of suspension.
 
-## TODO
-**7 PURGATORY & TERMINATION**
+**7 ALLOWLIST & TERMINATION**
 
-**7.1**	Purgatory is a state in which a publisher or data asset is tagged as "in purgatory". Being in purgatory has implications into how the asset is displayed in Ocean Market, and what actions are permitted to be performed on the asset. Once in purgatory, the asset or publisher may stay there or leave purgatory if certain conditions are fulfilled. 
+**7.1**    Allowlist is a state in which a Predictoor Feed is tagged as "allowed". Being allow has implications into how the asset is displayed in the Predictoor Portal, and whether the asset is incentivized by Predictoor DF.
 
-**7.2**	This agreement can be terminated at any time by discontinuing Customer access to and use of the Predictoor Stack. You will not receive any refunds, you agree that we, in our sole discretion and for any or no reason, may terminate these Terms and suspend and/or terminate the access to the Predictoor Stack and that we will not be liable to you or to any third party for any such suspension or termination.
+**7.2**    This agreement can be terminated at any time by discontinuing Customer access to and use of the Predictoor Stack. You will not receive any refunds, you agree that we, in our sole discretion and for any or no reason, may terminate these Terms and suspend and/or terminate the access to the Predictoor Stack and that we will not be liable to you or to any third party for any such suspension or termination.
 
 **8 INTELLECTUAL PROPERTY RIGHTS AND LICENSE**
 
-**8.1**    Except as provided in this Section 8, Ocean obtains no rights whatsoever under this Agreement from Customer (or Customer’s licensors) to published assets.
+**8.1**    Except as provided in this Section 8, Ocean obtains no rights whatsoever under this Agreement from Customer (or Customer’s licensors) to submitted predictions or Predictoor Feeds.
 
 **8.2**    Customer represents and warrants to Ocean that:
 
@@ -136,7 +135,7 @@ Customer acknowledges and agrees that the Commission will be transferred directl
 
 **8.4**    Except as provided in Section 8.3, the Customer obtains no rights under this Agreement from Ocean, Ocean affiliates or Ocean licensors to the Predictoor Stack, including any related intellectual property rights.
 
-**8.5**	Ocean Content and Third-Party Content may be provided to the Customer under a separate agreement and/or a separate license. In the event of a conflict between this Agreement and any separate agreement and/or separate license, the separate agreement and/or separate license will prevail with respect to the Ocean Content or Third-Party Content that is the subject of such separate agreement and/or separate license.
+**8.5**    Ocean Content and Third-Party Content may be provided to the Customer under a separate agreement and/or a separate license. In the event of a conflict between this Agreement and any separate agreement and/or separate license, the separate agreement and/or separate license will prevail with respect to the Ocean Content or Third-Party Content that is the subject of such separate agreement and/or separate license.
 
 **9 WARRANTIES; LIMITATIONS OF LIABILITY**
 


### PR DESCRIPTION
Fixes #252 

Changes proposed in this PR:
- [x] Create terms.md based off market.oceanprotocol.com
- [x] Defined predictoor-specific mechanisms that should be considered as part of the Terms
- [x] Adjusted/Created Definitions to encapsulate the core components that describe Predictoor.
- [x] Definitions include: Predictoor Feeds, Predictoor DF and Allowlist.

Example: `Purgatory`  => `Allowlist`
```
“**Allowlist**” means a state in which Ocean tags specific Predictoor Feeds to be visible in the Predictoor Portal and elligible for Predictoor DF rewards. The Allowlist is an artifact of deployed Predictoor Feeds that considered officially supported by Ocean. The Predictoor Portal Allowlist can be accessed here: https://github.com/oceanprotocol/pdr-web/blob/main/src/utils/config.ts
```