### PR TITLE
Fix #263, #270, #269: frontend accuracies, couldn't connect, multiple refresh

### DIFF
--- a/src/components/Accuracy.tsx
+++ b/src/components/Accuracy.tsx
@@ -1,11 +1,18 @@
+import { Maybe } from '@/utils/utils'
 import { ClipLoader } from 'react-spinners'
 import styles from '../styles/Accuracy.module.css'
 
-export default function Accuracy({ accuracy }: { accuracy: number }) {
+type TAccuracyProps = {
+  accuracy: Maybe<number>
+}
+
+export default function Accuracy({ accuracy }: TAccuracyProps) {
   // function receives accuracy as a number and returns a string
   // if accurcy has no decimals, add ".0" to the end
   // if accuracy has decimals, return accuracy with one decimal
-  const getFormattedAccuracy = (accuracy: number): string => {
+  const getFormattedAccuracy = (
+    accuracy: NonNullable<TAccuracyProps['accuracy']>
+  ): string => {
     if (accuracy % 1 === 0) {
       return `${accuracy}.0`
     } else {
@@ -15,7 +22,7 @@ export default function Accuracy({ accuracy }: { accuracy: number }) {
 
   return (
     <div className={styles.container}>
-      {accuracy !== undefined || accuracy !== null ? (
+      {accuracy !== null ? (
         <span className={styles.accuracy}>{`${getFormattedAccuracy(
           accuracy
         )}`}</span>

--- a/src/components/NotConnectedWarning.tsx
+++ b/src/components/NotConnectedWarning.tsx
@@ -1,8 +1,23 @@
+import { EEthereumClientStatus } from '@/hooks/useEthereumClient'
 import styles from '@/styles/Home.module.css'
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
-export const NotConnectedWarning = () => {
+export type TNotConnectedWarningProps = {
+  clientStatus:
+    | EEthereumClientStatus.DISCONNECTED
+    | EEthereumClientStatus.LOADING
+}
+
+export const NotConnectedWarning: React.FC<TNotConnectedWarningProps> = ({
+  clientStatus
+}) => {
   const [isClient, setIsClient] = useState(false)
+
+  const isClientLoading =
+    isClient && clientStatus === EEthereumClientStatus.LOADING
+
+  const isClientDisconnected =
+    isClient && clientStatus === EEthereumClientStatus.DISCONNECTED
 
   // Check if client-side
   useEffect(() => {
@@ -13,7 +28,8 @@ export const NotConnectedWarning = () => {
     <>
       <div className={styles.errorDescription}>
         <p className={styles.oneliner}>
-          {isClient &&
+          {(!isClient || isClientLoading) && ''}
+          {isClientDisconnected &&
             "Couldn't connect to the networks RPC. Try again latter."}
         </p>
       </div>

--- a/src/components/NotConnectedWarning.tsx
+++ b/src/components/NotConnectedWarning.tsx
@@ -1,11 +1,20 @@
 import styles from '@/styles/Home.module.css'
+import { useEffect, useState } from 'react'
 
 export const NotConnectedWarning = () => {
+  const [isClient, setIsClient] = useState(false)
+
+  // Check if client-side
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
+
   return (
     <>
       <div className={styles.errorDescription}>
         <p className={styles.oneliner}>
-          {"Couldn't connect to the networks RPC. Try again latter."}
+          {isClient &&
+            "Couldn't connect to the networks RPC. Try again latter."}
         </p>
       </div>
     </>

--- a/src/contexts/PredictoorsContext.tsx
+++ b/src/contexts/PredictoorsContext.tsx
@@ -26,6 +26,7 @@ import {
   DeepNonNullable,
   calculatePredictionEpochs,
   isSapphireNetwork,
+  isServerSide,
   omit
 } from '@/utils/utils'
 import { ethers } from 'ethers'
@@ -95,6 +96,7 @@ export const PredictoorsProvider: React.FC<TPredictoorsContextProps> = ({
 
   const { handleEpochData, initialEpochData } = useSocketContext()
   const [currentEpoch, setCurrentEpoch] = useState<number>(0)
+  const currentEpochRef = useRef(currentEpoch)
   const [secondsPerEpoch, setSecondsPerEpoch] = useState<number>(0)
   const [fetchingPredictions, setFetcingPredictions] = useState<boolean>(false)
 
@@ -127,6 +129,13 @@ export const PredictoorsProvider: React.FC<TPredictoorsContextProps> = ({
     useRef<Record<string, Array<TPredictedEpochLogItem>>>()
 
   const authorizationDataInstance = useRef<AuthorizationData<TAuthorization>>()
+
+  const checkAndSetCurrentEpoch = useCallback((epoch: number) => {
+    if (currentEpochRef.current === epoch) return
+    console.log('current epoch changed', epoch)
+    setCurrentEpoch(epoch)
+    currentEpochRef.current = epoch
+  }, [])
 
   const initializeAuthorizationData = useCallback(
     async (signer: ethers.providers.JsonRpcSigner) => {
@@ -282,7 +291,7 @@ export const PredictoorsProvider: React.FC<TPredictoorsContextProps> = ({
       contracts: Record<string, TPredictionContract>,
       signer: ethers.providers.JsonRpcSigner | undefined
     ) => {
-      if (typeof window === 'undefined') return
+      if (isServerSide()) return
 
       let tempSigner = signer
 
@@ -312,7 +321,7 @@ export const PredictoorsProvider: React.FC<TPredictoorsContextProps> = ({
           if (key == 0) {
             cEpoch = await predictoor.getCurrentEpoch()
             sPerEpoch = await predictoor.getSecondsPerEpoch()
-            setCurrentEpoch(cEpoch)
+            checkAndSetCurrentEpoch(cEpoch)
             setSecondsPerEpoch(sPerEpoch)
           }
           return predictoor
@@ -409,7 +418,7 @@ export const PredictoorsProvider: React.FC<TPredictoorsContextProps> = ({
 
         if (currentTs > cEpoch + SPE) {
           cEpoch = newCurrentEpoch * SPE
-          setCurrentEpoch(cEpoch)
+          checkAndSetCurrentEpoch(cEpoch)
         }
 
         const authorizationData =

--- a/src/hooks/useEthereumClient.ts
+++ b/src/hooks/useEthereumClient.ts
@@ -6,19 +6,31 @@ import { Chain, configureChains, createConfig } from 'wagmi'
 
 const w3mProjectId = process.env.NEXT_PUBLIC_WC2_PROJECT_ID || ''
 
+export enum EEthereumClientStatus {
+  'LOADING',
+  'CONNECTED',
+  'DISCONNECTED'
+}
+
 type TWagmiConfig = ReturnType<typeof createConfig>
 
 function useEthereumClient() {
   const [ethereumClient, setEthereumClient] =
     useState<Maybe<EthereumClient>>(null)
   const [wagmiConfig, setWagmiConfig] = useState<Maybe<TWagmiConfig>>(null)
+  const [status, setStatus] = useState<EEthereumClientStatus>(
+    EEthereumClientStatus.LOADING
+  )
 
   useEffect(() => {
     async function initializeEthereumClient() {
       await networkProvider.init()
       const chainInfo = networkProvider.getChainInfo()
 
-      if (!chainInfo) return
+      if (!chainInfo) {
+        setStatus(EEthereumClientStatus.DISCONNECTED)
+        return
+      }
 
       const chains: Array<Chain> = [chainInfo]
 
@@ -34,12 +46,13 @@ function useEthereumClient() {
 
       setWagmiConfig(config as TWagmiConfig)
       setEthereumClient(new EthereumClient(config, chains))
+      setStatus(EEthereumClientStatus.CONNECTED)
     }
 
     initializeEthereumClient()
   }, [])
 
-  return { ethereumClient, w3mProjectId, wagmiConfig }
+  return { ethereumClient, w3mProjectId, wagmiConfig, clientStatus: status }
 }
 
 export { useEthereumClient }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -14,6 +14,7 @@ import { MarketPriceProvider } from '@/contexts/MarketPriceContext'
 import { TimeFrameProvider } from '@/contexts/TimeFrameContext'
 import { useEthereumClient } from '@/hooks/useEthereumClient'
 import { EPredictoorContractInterval } from '@/utils/types/EPredictoorContractInterval'
+import { isServerSide } from '@/utils/utils'
 import { useRouter } from 'next/router'
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
@@ -22,10 +23,7 @@ import { useEffect, useMemo } from 'react'
 const inter = Inter({ subsets: ['latin'] })
 
 // Check that PostHog is client-side (used to handle Next.js SSR)
-if (
-  typeof window !== 'undefined' &&
-  process.env.NEXT_PUBLIC_POSTHOG == 'enabled'
-) {
+if (!isServerSide() && process.env.NEXT_PUBLIC_POSTHOG == 'enabled') {
   posthog.init(
     process.env.NEXT_PUBLIC_POSTHOG_KEY
       ? process.env.NEXT_PUBLIC_POSTHOG_KEY

--- a/src/utils/subgraphs/queries/getPredictSlots.ts
+++ b/src/utils/subgraphs/queries/getPredictSlots.ts
@@ -1,4 +1,5 @@
 export const SECONDS_IN_24_HOURS = 86400
+export const SECONDS_IN_1_WEEK = 604800
 
 export const GET_PREDICT_CONTRACTS = `
   query getContracts($assetIds: [String!]!) {
@@ -40,10 +41,14 @@ export const GET_PREDICT_SLOTS = `
       where: {
         slot_gte: $initialSlot
         predictContract_in: $assetIds
+        roundSumStakes_gt: "0"
       }
     ) {
       id
       slot
+      predictContract {
+        id
+      }
       trueValues {
         id
         trueValue
@@ -62,6 +67,9 @@ type TPredictSlotsTrueValue = {
 export type TPredictSlots = {
   id: string
   slot: number
+  predictContract: {
+    id: string
+  }
   trueValues: Array<TPredictSlotsTrueValue>
   roundSumStakesUp: string
   roundSumStakes: string

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -91,3 +91,5 @@ export const sleep = async (milliseconds: number) => {
     return setTimeout(resolve, milliseconds)
   })
 }
+
+export const isServerSide = () => typeof window === 'undefined'


### PR DESCRIPTION
Fixes #263 #270 #269 

Changes proposed in this PR:

- Merging all assets in a single graphql query to reduce the number of queries.
- Changing the 1-hour feeds to have 7-day samples for the accuracy calculating.
- Improving the state and shadow state references to prevent unnecessary refreshes.
- Disabling the warning text that gets rendered on the server-side.